### PR TITLE
Fix testagent's agent.NewTestAgent on Windows

### DIFF
--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -124,7 +124,7 @@ func (a *TestAgent) Start(t *testing.T) *TestAgent {
 		name = strings.Replace(name, "/", "_", -1)
 		d, err := ioutil.TempDir(TempDir, name)
 		require.NoError(err, fmt.Sprintf("Error creating data dir %s: %s", filepath.Join(TempDir, name), err))
-		hclDataDir = `data_dir = "` + d + `"`
+		hclDataDir = `data_dir = "` + filepath.ToSlash(d) + `"`
 	}
 	id := NodeID()
 


### PR DESCRIPTION
On windows

```go
func TestPKCAForConsultConnect(t *testing.T) {
	testAgent := agent.NewTestAgent(t, t.Name(), "")
}
```

crashes with

```
panic: Error building config: Error parsing TestConsult.data_dir: At 1:49: illegal char escape [recovered]
	panic: Error building config: Error parsing TestConsult.data_dir: At 1:49: illegal char escape

goroutine 6 [running]:
testing.tRunner.func1(0xc0002a6800)
	C:/Workspace/Scoop/apps/go/current/src/testing/testing.go:830 +0x399
panic(0x26dbcc0, 0xc000448900)
	C:/Workspace/Scoop/apps/go/current/src/runtime/panic.go:522 +0x1c3
github.com/hashicorp/consul/agent.TestConfig(0xc000229ea8, 0x3, 0x3, 0x2e45535)
	C:/workspace/gopath/src/bitbucket.global.standardchartered.com/nstspc/sc-cloud-welder/vendor/github.com/hashicorp/consul/agent/testagent.go:370 +0x904
github.com/hashicorp/consul/agent.(*TestAgent).Start(0xc000248e10, 0xc0002a6800, 0x518784)
	C:/workspace/gopath/src/bitbucket.global.standardchartered.com/nstspc/sc-cloud-welder/vendor/github.com/hashicorp/consul/agent/testagent.go:132 +0x63e
github.com/hashicorp/consul/agent.NewTestAgent(...)
```

This is because the data_dir hcl declaration created by default is not correct HCL:
For example:
```
data_dir = "C:\Users\ABC\AppData\Local\Temp\TestConsult-agent581490747"
```

Going back to "/" does fix the issue.